### PR TITLE
Added the checkout action prior to the spellcheck action

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -11,5 +11,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - name: Check Spelling
-        uses: rojopolis/spellcheck-github-actions@0.5.0
+    - uses: actions/checkout@develop
+    - uses: rojopolis/spellcheck-github-actions@0.5.0
+      name: Check Spelling
+

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - uses: actions/checkout@develop
+    - uses: actions/checkout@master
     - uses: rojopolis/spellcheck-github-actions@0.5.0
       name: Check Spelling
 


### PR DESCRIPTION
Hi @albertvolkman 

I have not observed [the issue](https://github.com/rojopolis/spellcheck-github-actions/issues/20) you reported with the Spellcheck Action.

I have added a minor change to your workflow definition, so the repository (development branch) is checked out for the action to both get the configuration and the files to check.

I will update the issue you reported and the documentation accordingly, but let me know if this PR is useful to you.

Take care and stay safe,

jonasbn 