### PR TITLE
[est-87] Fix active status for navigation items

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -17,7 +17,7 @@
         <ul class="dropdown vertical large-horizontal menu" data-dropdown-menu>
           {% for nav in site.data.menus.navigation %}
             <li>
-              <a class="{% if nav.button != 0 %}button {% endif %}{% if nav.url == page.url %} is-active{% endif %}" href="{{ nav.url }}">{{ nav.title }}</a>
+              <a class="{% if nav.button != 0 %}button {% endif %}{% if nav.url == page.dir %} is-active{% endif %}" href="{{ nav.url }}">{{ nav.title }}</a>
             </li>
           {% endfor %}
         </ul>


### PR DESCRIPTION
For some reason `page.url` variable returned `/blog/index.html` value instead `/blog/`
my fix is ​​returning correct values ​​for all pages